### PR TITLE
Option to make write group size configurable

### DIFF
--- a/db/write_thread.cc
+++ b/db/write_thread.cc
@@ -22,6 +22,10 @@ WriteThread::WriteThread(const ImmutableDBOptions& db_options)
       allow_concurrent_memtable_write_(
           db_options.allow_concurrent_memtable_write),
       enable_pipelined_write_(db_options.enable_pipelined_write),
+      lower_limit_write_batch_group_size_bytes(
+          db_options.lower_limit_write_batch_group_size_bytes),
+      upper_limit_write_batch_group_size_bytes(
+          db_options.upper_limit_write_batch_group_size_bytes),
       newest_writer_(nullptr),
       newest_memtable_writer_(nullptr),
       last_sequence_(0),
@@ -406,9 +410,9 @@ size_t WriteThread::EnterAsBatchGroupLeader(Writer* leader,
   // Allow the group to grow up to a maximum size, but if the
   // original write is small, limit the growth so we do not slow
   // down the small write too much.
-  size_t max_size = 1 << 20;
-  if (size <= (128 << 10)) {
-    max_size = size + (128 << 10);
+  size_t max_size = upper_limit_write_batch_group_size_bytes;
+  if (size <= lower_limit_write_batch_group_size_bytes) {
+    max_size = size + lower_limit_write_batch_group_size_bytes;
   }
 
   leader->write_group = write_group;
@@ -485,9 +489,9 @@ void WriteThread::EnterAsMemTableWriter(Writer* leader,
   // Allow the group to grow up to a maximum size, but if the
   // original write is small, limit the growth so we do not slow
   // down the small write too much.
-  size_t max_size = 1 << 20;
-  if (size <= (128 << 10)) {
-    max_size = size + (128 << 10);
+  size_t max_size = upper_limit_write_batch_group_size_bytes;
+  if (size <= lower_limit_write_batch_group_size_bytes) {
+    max_size = size + lower_limit_write_batch_group_size_bytes;
   }
 
   leader->write_group = write_group;

--- a/db/write_thread.h
+++ b/db/write_thread.h
@@ -360,6 +360,14 @@ class WriteThread {
   // Enable pipelined write to WAL and memtable.
   const bool enable_pipelined_write_;
 
+  // The lower limit of maximum number of bytes that are written in a single
+  // batch of WAL or memtable write.
+  const uint64_t lower_limit_write_batch_group_size_bytes;
+
+  // The upper limit of maximum number of bytes that are written in a single
+  // batch of WAL or memtable write.
+  const uint64_t upper_limit_write_batch_group_size_bytes;
+
   // Points to the newest pending writer. Only leader can remove
   // elements, adding can be done lock-free by anybody.
   std::atomic<Writer*> newest_writer_;

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -953,6 +953,16 @@ struct DBOptions {
   // Default: true
   bool enable_write_thread_adaptive_yield = true;
 
+  // The lower limit of maximum number of bytes that are written in a single
+  // batch of WAL or memtable write.
+  // Default: 128 KB
+  uint64_t lower_limit_write_batch_group_size_bytes = 128 << 10;
+
+  // The upper limit of maximum number of bytes that are written in a single
+  // batch of WAL or memtable write.
+  // Default: 1 MB
+  uint64_t upper_limit_write_batch_group_size_bytes = 2 << 20;
+
   // The maximum number of microseconds that a write operation will use
   // a yielding spin loop to coordinate with other write threads before
   // blocking on a mutex.  (Assuming write_thread_slow_yield_usec is

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -44,6 +44,10 @@ ImmutableDBOptions::ImmutableDBOptions(const DBOptions& options)
       table_cache_numshardbits(options.table_cache_numshardbits),
       wal_ttl_seconds(options.WAL_ttl_seconds),
       wal_size_limit_mb(options.WAL_size_limit_MB),
+      lower_limit_write_batch_group_size_bytes(
+          options.lower_limit_write_batch_group_size_bytes),
+      upper_limit_write_batch_group_size_bytes(
+          options.upper_limit_write_batch_group_size_bytes),
       manifest_preallocation_size(options.manifest_preallocation_size),
       allow_mmap_reads(options.allow_mmap_reads),
       allow_mmap_writes(options.allow_mmap_writes),
@@ -152,6 +156,14 @@ void ImmutableDBOptions::Dump(Logger* log) const {
   ROCKS_LOG_HEADER(log,
                    "                      Options.WAL_size_limit_MB: %" PRIu64,
                    wal_size_limit_mb);
+  ROCKS_LOG_HEADER(log,
+                   "                       "
+                   "Options.lower_limit_write_batch_group_size_bytes: %"
+                   PRIu64, lower_limit_write_batch_group_size_bytes);
+  ROCKS_LOG_HEADER(log,
+                   "                       "
+                   "Options.upper_limit_write_batch_group_size_bytes: %"
+                   PRIu64, upper_limit_write_batch_group_size_bytes);
   ROCKS_LOG_HEADER(
       log, "            Options.manifest_preallocation_size: %" ROCKSDB_PRIszt,
       manifest_preallocation_size);

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -43,6 +43,8 @@ struct ImmutableDBOptions {
   int table_cache_numshardbits;
   uint64_t wal_ttl_seconds;
   uint64_t wal_size_limit_mb;
+  uint64_t lower_limit_write_batch_group_size_bytes;
+  uint64_t upper_limit_write_batch_group_size_bytes;
   size_t manifest_preallocation_size;
   bool allow_mmap_reads;
   bool allow_mmap_writes;


### PR DESCRIPTION
The max batch size that we can write to the WAL is controlled by a static manner. So if the leader write is less than 128 KB we will have the batch size as leader write size + 128 KB else the limit will be 1 MB. Both of them are statically defined.